### PR TITLE
Add in a link to the Chef Server 12 triage docs for the 2014-10-15 min.

### DIFF
--- a/2014-10-15/2014-10-15-minutes.md
+++ b/2014-10-15/2014-10-15-minutes.md
@@ -46,7 +46,7 @@ Meeting called to order - 15:01 - nathenharvey
 
 * working on shipping Chef 12. After the Seattle Community summit we triaged all the issue and have an internal roadmap to address all that we thing are important enough to fix for the GA.
 * Expect more RCs
-* **ACTION ITEM** open the google doc, maybe, and mail the url out (after you sanitize it) - mmzyk
+* **ACTION ITEM** open the google doc, maybe, and mail the url out (after you sanitize it) - mmzyk - DONE - [Chef Server 12 Issue Triage and Progress Update](https://docs.google.com/a/opscode.com/document/d/1xqVTMt1_8q23VCkQOQGFcMMvSf3ZKj1wjsmx8O7vqRI/edit)
 * Response to POODLE [posted to the blog](https://www.getchef.com/blog/2014/10/14/security-response-ssl-poodle-attack-and-mitigation/)
 * Provisioning update
   * A new ASW native metal gem has been written with support for way more things (like load balancers)


### PR DESCRIPTION
As the title says, as a link to the promised public triage and update doc for the Chef Server 12.
